### PR TITLE
Ajuste na exceção divisão não exata  e Implementação de duas outras exceções personalizadas.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
-  </component>
   <component name="ProjectKey">
     <option name="state" value="project://e2804f05-5315-4fc6-a121-c522a6c26470" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/br/com/dio/exceptions/DivisaoPorZeroException.java
+++ b/src/br/com/dio/exceptions/DivisaoPorZeroException.java
@@ -1,0 +1,12 @@
+package br.com.dio.exceptions;
+
+public class DivisaoPorZeroException extends Exception {
+
+        private int denominador;
+
+        public DivisaoPorZeroException(String message, int denominador) {
+            super(message);
+            this.denominador = denominador;
+        }
+
+}

--- a/src/br/com/dio/exceptions/ExceptionCustomizada_2.java
+++ b/src/br/com/dio/exceptions/ExceptionCustomizada_2.java
@@ -1,24 +1,38 @@
 package br.com.dio.exceptions;
 
 import javax.swing.*;
+import java.util.Arrays;
 
 public class ExceptionCustomizada_2 {
     public static void main(String[] args){
         int[] numerador = {4, 5, 8, 10};
         int[] denominador = {2, 4, 0, 2, 8};
 
+
         for (int i = 0; i < denominador.length; i++) {
-            try {
-                if(numerador[i] %2 != 0)
-                    throw new DivisaoNaoExataException("Divisão não exata!", numerador[i], denominador[i]);
+            try{
+                if(denominador[i] == 0)
+                    throw new DivisaoPorZeroException("Divisao por Zero",denominador[i]);
+                try {
+                    if (numerador[i] % denominador[i] != 0)
+                        throw new DivisaoNaoExataException("Divisão não exata!", numerador[i], denominador[i]);
+                }catch(ArrayIndexOutOfBoundsException e){
+                    throw new TamanhoDoArrayInvalidoException("Tamanho do Array Invalido", i);
+                }
 
                 int resultado = numerador[i] / denominador[i];
                 System.out.println(resultado);
-            } catch (DivisaoNaoExataException | ArithmeticException | ArrayIndexOutOfBoundsException e) {
-                e.printStackTrace();
+
+
+            } catch (DivisaoNaoExataException | DivisaoPorZeroException | TamanhoDoArrayInvalidoException e) {
+                // e.printStackTrace();
                 JOptionPane.showMessageDialog(null, e.getMessage());
             }
+
+
+
         }
+
 
         System.out.println("O programa continua...");
     }

--- a/src/br/com/dio/exceptions/TamanhoDoArrayInvalidoException.java
+++ b/src/br/com/dio/exceptions/TamanhoDoArrayInvalidoException.java
@@ -1,0 +1,11 @@
+package br.com.dio.exceptions;
+
+public class TamanhoDoArrayInvalidoException extends Exception{
+
+      private int i;
+
+        public TamanhoDoArrayInvalidoException(String message, int i) {
+            super(message);
+            this.i = i;
+        }
+}


### PR DESCRIPTION
ola camila tudo bem, vi seus videos nas aulas da dio, e durante uma das aulas vc  criou uma exceção personalizada da divisão não exata , acontece que vc faz a extração do resto fazendo numerador % 2 , porém esse caso so vai identificar que o valor é par ou impar , pois pode acontecer situações entre pares também retornarem valores quebrados , como por exemplo 6/4 não é o caso do nosso exemplo mas se for identificar se essa divisão ela vai dar exata, ou não, o certo é extrair o mod entre o numerador e o denominador assim o teste seria mais assertivo, fazendo vc ter uma certeza melhor na hora de tratar esse erro da divisão não exata. Se de repente o array tivesse um numerador 6 e um divisor 4 no mesmo indice pelo seu codigo daria uma falso positivo para divisão exata, com essa alteração que fiz vc garante que vai dar exata ou não pelo resto da divisão do numerador pelo denominador,  também aproveitei e implementei os outros duas exceções personalizadas substituindo ArithmeticException | ArrayIndexOutOfBoundsException por DivisaoPorZeroException | TamanhoDoArrayInvalidoException espero que esteja certa a minha implementação. Abraços. 